### PR TITLE
add the max_file_size parameter for leveldb

### DIFF
--- a/plyvel/_plyvel.pyx
+++ b/plyvel/_plyvel.pyx
@@ -146,9 +146,9 @@ cdef int parse_options(Options *options, c_bool create_if_missing,
                        c_bool error_if_exists, object paranoid_checks,
                        object write_buffer_size, object max_open_files,
                        object lru_cache_size, object block_size,
-                       object block_restart_interval, object compression,
-                       int bloom_filter_bits, object comparator,
-                       bytes comparator_name) except -1:
+                       object block_restart_interval, object max_file_size,
+                       object compression, int bloom_filter_bits,
+                       object comparator, bytes comparator_name) except -1:
     cdef size_t c_lru_cache_size
 
     options.create_if_missing = create_if_missing
@@ -173,6 +173,9 @@ cdef int parse_options(Options *options, c_bool create_if_missing,
 
     if block_restart_interval is not None:
         options.block_restart_interval = block_restart_interval
+
+    if max_file_size is not None:
+        options.max_file_size = max_file_size
 
     if compression is None:
         options.compression = leveldb.kNoCompression
@@ -218,9 +221,9 @@ cdef class DB:
                  bool error_if_exists=False, paranoid_checks=None,
                  write_buffer_size=None, max_open_files=None,
                  lru_cache_size=None, block_size=None,
-                 block_restart_interval=None, compression='snappy',
-                 int bloom_filter_bits=0, object comparator=None,
-                 bytes comparator_name=None):
+                 block_restart_interval=None, max_file_size=None,
+                 compression='snappy', int bloom_filter_bits=0,
+                 object comparator=None, bytes comparator_name=None):
         cdef Status st
         cdef string fsname
         self.name = name
@@ -229,8 +232,8 @@ cdef class DB:
         parse_options(
             &self.options, create_if_missing, error_if_exists, paranoid_checks,
             write_buffer_size, max_open_files, lru_cache_size, block_size,
-            block_restart_interval, compression, bloom_filter_bits, comparator,
-            comparator_name)
+            block_restart_interval, max_file_size, compression, bloom_filter_bits,
+            comparator, comparator_name)
         with nogil:
             st = leveldb.DB_Open(self.options, fsname, &self._db)
         raise_for_status(st)
@@ -498,8 +501,8 @@ cdef class PrefixedDB:
 
 def repair_db(name, *, paranoid_checks=None, write_buffer_size=None,
               max_open_files=None, lru_cache_size=None, block_size=None,
-              block_restart_interval=None, compression='snappy',
-              int bloom_filter_bits=0, comparator=None,
+              block_restart_interval=None, max_file_size=None,
+              compression='snappy', int bloom_filter_bits=0, comparator=None,
               bytes comparator_name=None):
     cdef Options options = Options()
     cdef Status st
@@ -511,8 +514,8 @@ def repair_db(name, *, paranoid_checks=None, write_buffer_size=None,
     parse_options(
         &options, create_if_missing, error_if_exists, paranoid_checks,
         write_buffer_size, max_open_files, lru_cache_size, block_size,
-        block_restart_interval, compression, bloom_filter_bits, comparator,
-        comparator_name)
+        block_restart_interval, max_file_size, compression, bloom_filter_bits,
+        comparator, comparator_name)
     with nogil:
         st = RepairDB(fsname, options)
     raise_for_status(st)

--- a/plyvel/leveldb.pxd
+++ b/plyvel/leveldb.pxd
@@ -69,6 +69,7 @@ cdef extern from "leveldb/options.h" namespace "leveldb":
         Cache* block_cache
         size_t block_size
         int block_restart_interval
+        size_t max_file_size
         CompressionType compression
         FilterPolicy* filter_policy
         Options() nogil


### PR DESCRIPTION
Add option for max file size. The currend hard-coded value of 2M is
inefficient in colossus.

ref:
    https://github.com/google/leveldb/commit/a2fb086d07b7dbd9c4a59fe57646bd465841edd5